### PR TITLE
Add missing <memory> header to URT.hpp

### DIFF
--- a/include/URT.hpp
+++ b/include/URT.hpp
@@ -109,6 +109,7 @@
 
 #include <fstream>
 #include <map>
+#include <memory>
 
 #include <boost/math/distributions/students_t.hpp>
 #include <boost/math/special_functions/gamma.hpp>


### PR DESCRIPTION
New Boost versions cut their unnecessary dependencies, and this has to be reflected in the client software.

PS. @olmallet81 I have more contributions, if you're interested.